### PR TITLE
Add ability to create auto-recurring subscriptions

### DIFF
--- a/cybersource.php
+++ b/cybersource.php
@@ -393,7 +393,7 @@
 		 * @param boolean|null $auto_authorize Set to false to enable the disableAutoAuth flag to avoid an authorization and simply store the card. The default (null) means to omit the value, which means it'll use the setting on the account. Set to true to force an authorization, whether the account requires it or not.
 		 * @return stdClass The raw response object from the SOAP endpoint
 		 */
-		public function create_subscription ( $request_id = null, $auto_authorize = null ) {
+		public function create_subscription ( $request_id = null, $auto_authorize = null, $subscription_info = null ) {
 			
 			$request = $this->create_request();
 			
@@ -417,9 +417,11 @@
 			
 			$request->paySubscriptionCreateService = $subscription_create;
 			
-			// specify that this is an on-demand subscription, it should not auto-bill
-			$subscription_info = new stdClass();
-			$subscription_info->frequency = 'on-demand';
+			if ( $subscription_info == null ) {
+				// specify that this is an on-demand subscription, it should not auto-bill
+				$subscription_info = new stdClass();
+				$subscription_info->frequency = 'on-demand';
+			}
 			$request->recurringSubscriptionInfo = $subscription_info;
 			
 			// we only need to add billing info to the request if there is not a previous request token - otherwise it's contained in it


### PR DESCRIPTION
I have added a patch to your create_subscription method to allow passing in the $subscription_info variable.

This is needed for my own use-case and I thought perhaps others can benefit from the tweak. I appreciate your work on this library - it's much better than anything CyberSource provides. Thanks.
