### PR TITLE
Sending item details

### DIFF
--- a/classes/CyberSource/CyberSource.php
+++ b/classes/CyberSource/CyberSource.php
@@ -529,9 +529,10 @@
 		 * 
 		 * @param string $subscription_id The CyberSource Subscription ID to charge.
 		 * @param float $amount The dollar amount to charge.
+		 * @param boolean $auto_settle Set to false if you don't want to settle the payment automatically
 		 * @return stdClass The raw response object from the SOAP endpoint
 		 */
-		public function charge_subscription ( $subscription_id, $amount = null ) {
+		public function charge_subscription ( $subscription_id, $amount = null, $auto_settle = true ) {
 			
 			$request = $this->create_request();
 			
@@ -542,7 +543,7 @@
 			
 			// and actually charge them
 			$cc_capture_service = new \stdClass();
-			$cc_capture_service->run = 'true';
+			$cc_capture_service->run = $auto_settle ? 'true' : 'false';
 			$request->ccCaptureService = $cc_capture_service;
 			
 			// actually remember to add the subscription ID that we're billing... duh!

--- a/classes/CyberSource/CyberSource.php
+++ b/classes/CyberSource/CyberSource.php
@@ -17,6 +17,7 @@
 		public $merchant_id;
 		public $transaction_id;
 		public $reference_code = 'Unknown';		// for backend transaction reporting
+		public $fail_on_unaccapted_transaction = true;
 		
 		public $bill_to = array();
 		public $card = array();
@@ -177,6 +178,12 @@
 		public function reference_code ( $code ) {
 			$this->reference_code = $code;
 			
+			return $this;
+		}
+
+		public function fail_on_unaccapted_transaction ( $fail_on_unaccapted_transaction ) {
+			$this->fail_on_unaccapted_transaction = $fail_on_unaccapted_transaction;
+
 			return $this;
 		}
 		
@@ -701,7 +708,7 @@
 			// save the whole response so you can get everything back even on an exception
 			$this->response = $response;
 			
-			if ( $response->decision != 'ACCEPT' ) {
+			if ( $this->fail_on_unaccapted_transaction && $response->decision != 'ACCEPT' ) {
 				
 				// customize the error message if the reason indicates a field is missing
 				if ( $response->reasonCode == 101 ) {
@@ -738,11 +745,11 @@
 				// otherwise, just throw a generic declined exception
 				if ( $response->decision == 'ERROR' ) {
 					// note that ERROR means some kind of system error or the processor rejected invalid data - it probably doesn't mean the card was actually declined
-					throw new CyberSource_Error_Exception( $this->result_codes[ $response->reasonCode ], $response->reasonCode );
+					throw new CyberSource_Error_Exception( @$this->result_codes[ $response->reasonCode ], $response->reasonCode );
 				}
 				else {
 					// declined, however, actually means declined. this would be decision 'REJECT', btw.
-					throw new CyberSource_Declined_Exception( $this->result_codes[ $response->reasonCode ], $response->reasonCode );
+					throw new CyberSource_Declined_Exception( @$this->result_codes[ $response->reasonCode ], $response->reasonCode );
 				}
 			}
 			


### PR DESCRIPTION
As per the [CyberSource API docs](http://apps.cybersource.com/library/documentation/dev_guides/CC_Svcs_SO_API/Credit_Cards_SO_API.pdf) there are several additional fields that items accept. I made changes to send these along too.

An example:

``` php
$cybersourceApi->add_item(
    '55.00', // unit price
    1, // quantity
    array(
        'productCode'   => 'electronic_good',
        'productName'   => '50 credits',
        'productSKU'    => '111',
    )
);
```
